### PR TITLE
enable jbang direct run

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,9 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "cowsay": {
+      "script-ref": "com.github.ricksbrown:cowsay:LATEST"
+    }
+  },
+  "templates": {}
+}


### PR DESCRIPTION
Super important utility you made here. It should be more accessible thus I suggest to enable jbang for it.

with this PR you can use jbang.dev and run it with `jbang cowsay@ricksbrown/cowsay Hello`

Alternatively If you made a ricksbrown/jbang-catalog  repo and put jbang-catalog.json in here it would be just `jbang cowsay@ricksbrown"